### PR TITLE
fix: exit gracefully upon subnet metagraph api not found

### DIFF
--- a/src/core/substrate/exceptions/substrate.exception-filter.ts
+++ b/src/core/substrate/exceptions/substrate.exception-filter.ts
@@ -28,8 +28,8 @@ export class SubstrateExceptionFilter extends KamiBaseExceptionFilter {
 
     // Known error patterns
     if (
-      message.includes('WebSocket is not connected') ||
-      stack?.includes('WebSocket is not connected')
+      message.includes('WebSocket is not connected'.toLowerCase()) ||
+      stack?.includes('WebSocket is not connected'.toLowerCase())
     ) {
       return new ConnectionFailedException(error.message, error.stack);
     }

--- a/src/features/subnet-metagraph/subnet-metagraph.exception-filter.ts
+++ b/src/features/subnet-metagraph/subnet-metagraph.exception-filter.ts
@@ -14,6 +14,17 @@ export class SubnetMetagraphExceptionFilter extends KamiBaseExceptionFilter {
 
     this.logger.debug(`🔍 Mapping error: "${message}"`);
 
+    if (message.includes('API SubnetInfoRuntimeApi not found in runtime metadata'.toLowerCase())) {
+      this.logger.error(
+        `🚨 Critical error: ${message}. The runtime API is not available. Initiating graceful shutdown...`,
+      );
+
+      setTimeout(() => {
+        this.logger.log('🛑 Exiting application gracefully due to runtime incompatibility...');
+        process.exit(0);
+      }, 1000);
+    }
+
     // Catch all
     this.logger.log(`⚠️ Mapped to: Generic SubnetMetagraphException (unknown error)`);
     return new SubnetMetagraphUnknownException(error.message, error.stack);

--- a/src/features/subnet-metagraph/subnet-metagraph.service.ts
+++ b/src/features/subnet-metagraph/subnet-metagraph.service.ts
@@ -13,7 +13,7 @@ export class SubnetMetagraphService {
   constructor(
     private readonly substrateClientService: SubstrateClientService,
     private readonly substrateConnectionService: SubstrateConnectionService,
-  ) { }
+  ) {}
 
   async getSubnetMetagraph(netuid: number): Promise<SubnetMetagraph> {
     try {

--- a/src/features/subnet-metagraph/subnet-metagraph.service.ts
+++ b/src/features/subnet-metagraph/subnet-metagraph.service.ts
@@ -36,20 +36,6 @@ export class SubnetMetagraphService {
         throw error;
       }
 
-      if (
-        error.message &&
-        error.message.includes('API SubnetInfoRuntimeApi not found in runtime metadata')
-      ) {
-        this.logger.error(
-          `🚨 Critical error: ${error.message}. The runtime API is not available. Initiating graceful shutdown...`,
-        );
-
-        setTimeout(() => {
-          this.logger.log('🛑 Exiting application gracefully due to runtime incompatibility...');
-          process.exit(0);
-        }, 1000);
-      }
-
       throw new SubnetMetagraphException(
         HttpStatus.INTERNAL_SERVER_ERROR,
         'UNKNOWN',


### PR DESCRIPTION
- causes kami to exit gracefully upon this error to force a restart for now until we find a better solution